### PR TITLE
Pf 47 create update self query

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GithubSharedProjectSettings">
+    <option name="branchProtectionPatterns">
+      <list>
+        <option value="dev" />
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/backend/src/graphql/user.js
+++ b/backend/src/graphql/user.js
@@ -63,7 +63,7 @@ const userUpdateSelf = UserTCPublic.mongooseResolvers.updateById()
 
 const UserQuery = {
     ...requireAuthentication({
-        userSelf: UserTCPublic.getResolver("userSelf"),
+        userSelf,
         user: UserTCPublic.mongooseResolvers.findOne(), //TODO restrict filters
     }),
     ...requireAuthorization({

--- a/backend/src/graphql/user.js
+++ b/backend/src/graphql/user.js
@@ -46,13 +46,11 @@ UserTCPublic.addResolver({
     resolve: async ({args}) => {
         const user = await User.findOne({email: args.email});
 
-        //OPTIMIZE/FIXME 2 different error messages -> "hacker" can find out which emails exist and which dont
-        // if we want to fix the error, we still need a pseudo-compare password cause else a "hacker" can do
-        // timing attacks -> as a login takes substantially longer if the user is correct due to comparing a password
+        //OPTIMIZE/FIXME
+        // timing attacks -> as a login takes substantially longer if the user is correct due to comparing a password,
         // a "hacker" can use the difference in time-till-response to find out which emails are in use
         // SEVERITY: minor
-        if (!user) throw new Error("User does not exist.")
-        if (!await user.comparePassword(args.password)) throw new Error("Password is not correct.");
+        if (!user || !await user.comparePassword(args.password)) throw new Error("User or Password is not correct.");
 
         //generate token
         return jwt.sign({

--- a/backend/src/graphql/user.js
+++ b/backend/src/graphql/user.js
@@ -31,7 +31,7 @@ UserTCPublic.addResolver({
     resolve: async ({args}) => {
         const user = await User.findOne({email: args.email});
 
-        //OPTIMIZE/FIXME
+        //FIXME
         // timing attacks -> as a login takes substantially longer if the user is correct due to comparing a password,
         // a "hacker" can use the difference in time-till-response to find out which emails are in use
         // SEVERITY: minor

--- a/backend/src/graphql/user.js
+++ b/backend/src/graphql/user.js
@@ -1,12 +1,12 @@
 const jwt = require("jsonwebtoken");
-const {User, UserTCAdmin, UserTCSignup, UserTCPublic} = require("../models/user/user");
+const {User, UserTCAdmin, UserTCSignup, UserTCPublic, UserTCPrivate} = require("../models/user/user");
 const requireAuthentication = require("../middleware/jwt/requireAuthentication");
 const requireAuthorization = require("../middleware/jwt/requireAuthorization");
 
 //**********************
 //*** custom queries ***
 //**********************
-const userSelf = UserTCPublic.mongooseResolvers
+const userSelf = UserTCPrivate.mongooseResolvers
     .findById()
     .setDescription("Get information of currently logged in user")
     .removeArg("_id")
@@ -49,7 +49,8 @@ UserTCPublic.addResolver({
     }
 })
 
-const userUpdateSelf = UserTCPublic.mongooseResolvers.updateById()
+
+const userUpdateSelf = UserTCPrivate.mongooseResolvers.updateById()
     .setDescription("Update information of currently logged in user")
     .removeArg("_id")
     .wrapResolve((next) => (rp) => {

--- a/backend/src/graphql/user.test.js
+++ b/backend/src/graphql/user.test.js
@@ -192,7 +192,7 @@ describe("User GraphQL Test Suite", () => {
                 }
             }
         )
-        expect(loginFalseEmailResult.errors[0].message).toBe("User does not exist.")
+        expect(loginFalseEmailResult.errors[0].message).toBe("User or Password is not correct.")
 
         const {email: email2, password: password2} = testUsers.validNoDefaults
         const loginFalsePasswordResult = await mutate(
@@ -203,7 +203,7 @@ describe("User GraphQL Test Suite", () => {
                 }
             }
         )
-        expect(loginFalsePasswordResult.errors[0].message).toBe("Password is not correct.")
+        expect(loginFalsePasswordResult.errors[0].message).toBe("User or Password is not correct.")
     })
 
     it("executes requireAuthentication queries", async () => {

--- a/backend/src/graphql/user.test.queries.js
+++ b/backend/src/graphql/user.test.queries.js
@@ -16,15 +16,15 @@ const LOGIN = `
         login(email: $email, password: $password)
     }
 `
-
 const USER_SELF = `
     query {
         userSelf{
         name
+        email
         aboutMe
         languages
         gender
-        age
+        dateOfBirth
         avatar
         ingameRole
         }

--- a/backend/src/models/user/user.js
+++ b/backend/src/models/user/user.js
@@ -157,6 +157,21 @@ const UserTCAdmin = composeMongoose(User, {
     description: "Full User Model. Exposed only for Admins"
 });
 
+const UserTCPrivate = composeMongoose(User, {
+    name: "UserPrivate",
+    description: "Fields the user can see about himself",
+    onlyFields: [
+        "name",
+        "email",
+        "aboutMe",
+        "languages",
+        "gender",
+        "dateOfBirth",
+        "avatar",
+        "ingameRole",
+    ]
+})
+
 
 const UserTCPublic = composeMongoose(User, {
     name: "UserPublic",
@@ -194,10 +209,12 @@ const ageForTC ={
 UserTCAdmin.addFields(ageForTC)
 UserTCPublic.addFields(ageForTC)
 
+
 module.exports = {
     User,
     UserTCAdmin,
     UserTCPublic,
+    UserTCPrivate,
     UserTCSignup
 }
 

--- a/backend/src/models/user/user.js
+++ b/backend/src/models/user/user.js
@@ -119,6 +119,7 @@ const UserSchema = new mongoose.Schema({
 UserSchema.virtual("age").get(function () {
     //https://stackoverflow.com/a/24181701/12340711
     //good enough
+    if (!this.dateOfBirth) return -1 //default
     const ageDifMs = Date.now() - this.dateOfBirth
     const ageDate = new Date(ageDifMs); // miliseconds from epoch
     return Math.abs(ageDate.getUTCFullYear() - 1970);
@@ -186,7 +187,7 @@ const UserTCSignup = composeMongoose(User, {
 const ageForTC ={
     age: {
         type: "Int",
-        description: 'Uses the virtual "age" that is calculated from DateOfBirth',
+        description: 'Uses the virtual "age" that is calculated from DateOfBirth. Returns -1 if DateOfBirth is not set.',
     }
 }
 

--- a/backend/src/utils/createLanguages.js
+++ b/backend/src/utils/createLanguages.js
@@ -10,6 +10,7 @@ function mongooseLanguages() {
             _id: current["639-1"],
             name: current["name"],
             nativeName: current["nativeName"],
+            emoji: current["emoji"],
         })
     })
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -86,6 +86,8 @@ type Mutation {
         skip: Int,
         sort: SortUpdateOneUserAdminInput
     ): UpdateOneUserAdminPayload
+    "Update information of currently logged in user"
+    userUpdateSelf(record: UpdateByIdUserPublicInput!): UpdateByIdUserPublicPayload
 }
 
 "Information about pagination in a connection."
@@ -170,7 +172,7 @@ type Query {
         perPage: Int = 20,
         sort: SortFindManyUserAdminInput
     ): UserAdminPagination
-    "get public schema of currently logged in user"
+    "Get information of currently logged in user"
     userSelf: UserPublic
 }
 
@@ -208,6 +210,15 @@ type UpdateByIdUserAdminPayload {
     recordId: MongoID
 }
 
+type UpdateByIdUserPublicPayload {
+    "Error that may occur during operation. If you request this field in GraphQL query, you will receive typed error in payload; otherwise error will be provided in root `errors` field of GraphQL response."
+    error: ErrorInterface
+    "Updated document"
+    record: UserPublic
+    "Document ID"
+    recordId: MongoID
+}
+
 type UpdateManyUserAdminPayload {
     "Error that may occur during operation. If you request this field in GraphQL query, you will receive typed error in payload; otherwise error will be provided in root `errors` field of GraphQL response."
     error: ErrorInterface
@@ -228,7 +239,7 @@ type UpdateOneUserAdminPayload {
 type UserAdmin {
     _id: MongoID!
     aboutMe: String
-    "Uses the virtual \"age\" that is calculated from DateOfBirth"
+    "Uses the virtual \"age\" that is calculated from DateOfBirth. Returns -1 if DateOfBirth is not set."
     age: Int
     avatar: String
     createdAt: Date
@@ -275,7 +286,7 @@ type UserAdminPagination {
 "Contains all public fields of users. Use this for filtering as well"
 type UserPublic {
     aboutMe: String
-    "Uses the virtual \"age\" that is calculated from DateOfBirth"
+    "Uses the virtual \"age\" that is calculated from DateOfBirth. Returns -1 if DateOfBirth is not set."
     age: Int
     avatar: String
     gender: EnumUserPublicGender!
@@ -1062,6 +1073,15 @@ input UpdateByIdUserAdminInput {
     password: String
     role: EnumUserAdminRole
     updatedAt: Date
+}
+
+input UpdateByIdUserPublicInput {
+    aboutMe: String
+    avatar: String
+    gender: EnumUserPublicGender
+    ingameRole: [EnumUserPublicIngameRole]
+    languages: [String]
+    name: String
 }
 
 input UpdateManyUserAdminInput {


### PR DESCRIPTION
we now have an additional UserTCPrivate - used for user(Update)Self queries/mutations.
This TC has some more fields (email, dateOfBirth) that should be available to the user itself, but not for the public.

The updateSelf query now also exist to allow a logged in user to change it's information - change preferred roles, set the spoken languages etc. You can use it in /settings ^^